### PR TITLE
schemaUrl Property to document the API schema used by the service

### DIFF
--- a/service-info.yaml
+++ b/service-info.yaml
@@ -50,6 +50,10 @@ components:
           type: string
           description: 'URL of the documentation of this service (RFC 3986 format). This should help someone learn how to use your service including any specifics required to access data, e.g. authentication.'
           example: 'https://docs.example.com'
+        schemaUrl:
+          type: string
+          description: 'URL of the API schema used by this service (RFC 3986 format). This should help machine code to self-configure and use the service'
+          example: 'https://example.com/swagger.yaml'
         organization:
           type: string
           description: 'A short string used to identify the organization providing this service.'


### PR DESCRIPTION
I feel it may be worth adding the explicit URL to the API schema used by the service. This would allow clients to detect the API schema used by the service and self-configure. This could point to the GA4GH YAML spec or a local copy that may add non-breaking extensions. See example below:
```yaml
schemaUrl:
  type: string
  description: URL of the schema of this service (RFC 3986 format).
```

Related GA4GH DRS /service-info PR #277 discussion.

Resolves #26