### PR TITLE
Removing HTTP response codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ When responding to a request a server MUST use the fully specified media type fo
 
 No vendor specific description has been given here as service-info intends should be incorporated into other specifications.
 
-### HTTP Response Codes
-
-- `200`: indicates a successful request and response
-- `4XX`: indicates a unsuccessful response due to a client error
-- `5XX`: indicates a unsuccessful response due to a server error
-
 ## Security
 
 Service metadata is viewed as public data and can be provided without restriction. However, an implementation may choose to distribute additional metadata, which may be considered sensitive. Effective security measures are essential to protect the integrity and confidentiality of these data.


### PR DESCRIPTION
Issue #25 has decided we should remove any reference to HTTP response codes since service info is not expected to work. There are no error situations the API should encounter.