### PR TITLE
Feature/maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,4 +11,4 @@ Even those with write access to the **ga4gh-discovery/ga4gh-service-info** repos
 
 ## Documents to update
 
-Service-info's main specification document is the [service-info.yaml OpenAPI document](./service-info.yaml). In addition, [service-info's README.md](./README.md) contains higher level information about the specification and must be kept in-line with changes to the OpenAPI document.
+Service-info's main specification document is the [service-info.yaml OpenAPI document](service-info.yaml). In addition, [service-info's README.md](README.md) contains higher level information about the specification and must be kept in-line with changes to the OpenAPI document.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Specification maintainers
+
+* Miro Cupak (@mcupak)
+* Andy Yates (@andrewyatz)
+
+## Updating the specifications
+
+Minor editorial fixes where there is no likelihood of controversy may be done directly on the **master** branch. Larger changes should be proposed as pull requests so that they can be discussed and refined. 
+
+Even those with write access to the **ga4gh-discovery/ga4gh-service-info** repository should in general create their pull request branches within their own **ga4gh-service-info** forks. This way when the main repository is forked again, the new fork is created with a minimum of extraneous volatile branches.
+
+## Documents to update
+
+Service-info's main specification document is the [service-info.yaml OpenAPI document](./service-info.yaml). In addition, [service-info's README.md](./README.md) contains higher level information about the specification and must be kept in-line with changes to the OpenAPI document.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The policies and processes used to perform user authentication and authorization
 
 ## How to contribute
 
-Guidelines for contributing to this repository are listed in [CONTRIBUTING.md](CONTRIBUTING.md).
+Guidelines for contributing to this repository are listed in [CONTRIBUTING.md](CONTRIBUTING.md). Information on the specification maintainers is available from [MAINTAINERS.md](MAINTAINERS.md).
 
 ## How to notify GA4GH of potential security flaws
 


### PR DESCRIPTION
Adding a new document to track the maintainers of the spec. Taking inspiration from hts-specs, which admittedly is tracking multiple specs in a single repo. Might mean it is easier to roll some of this into the README