### PR TITLE
Make examples less specific

### DIFF
--- a/service-info.yaml
+++ b/service-info.yaml
@@ -51,7 +51,7 @@ components:
         name:
           type: string
           description: 'Name of this service. Should be human readable.'
-          example: '1000 Genomes Project'
+          example: 'Project name'
         type:
           type: string
           description: |
@@ -59,14 +59,12 @@ components:
             - groupId: Reversed domain name (e.g. org.ga4gh).
             - artifactId: Name of the artifact or specification without version (e.g. beacon; drs).
             - version: Version number (e.g. 1.0.1).
-          example: 'org.ga4gh:beacon:1.0.1'
+          example: 'org.ga4gh:service:1.0.1'
         description:
           type: string
           description: 'Description of the service. Should be human readable and provide information about the service.'
           example: |
-            The 1000 Genomes Project provides a large public catalogue of
-            human genome variation data which serves as standard reference
-            in many genomic workflows and analysis projects.
+            This service provides ......
         documentationUrl:
           type: string
           description: 'URL of the documentation of this service (RFC 3986 format). This should help someone learn how to use your service including any specifics required to access data, e.g. authentication.'
@@ -77,6 +75,7 @@ components:
           example: 'EMBL-EBI'
         contactUrl:
           type: string
+          format: uri
           description: 'URL of the contact for the host/maintainer of this service, e.g. a link to a contact form (RFC 3986 format), or an email (RFC 2368 format).'
           example: 'mailto:support@example.com'
         version:


### PR DESCRIPTION
Fixing #47. Creating very specific examples of content can create confusing downstream documentation. Switch to more generic examples to help downstream versions. Also clarified the format of the email attribute