### PR TITLE
Include authorization information in service info response

### DIFF
--- a/service-info.yaml
+++ b/service-info.yaml
@@ -100,6 +100,8 @@ components:
           type: string
           description: 'Version of the service being described. Semantic versioning is recommended, but other identifiers, such as dates or commit hashes, are also allowed. The version should be changed whenever the service is updated.'
           example: '1.0.0'
+        authInfo:
+          $ref: '#/components/schemas/AuthInfo'
     ServiceType:
       description: 'Type of a GA4GH service'
       type: object
@@ -120,3 +122,70 @@ components:
           type: string
           description: 'Version of the API or specification. GA4GH specifications use semantic versioning.'
           example: '1.0.0'
+    AuthInfo:
+      description: Provides information on how to authenticate and authorize to the web service, enabling automated client auth
+      type: object
+      required:
+        - authServer
+        - scopeDefinitions
+      properties:
+        authServer:
+          $ref: '#/components/schemas/AuthServer'
+        scopeDefinitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScopeDefinition'
+    AuthServer:
+      type: object
+      description: |
+        The authorization server responsible for authorizing clients/users to the web service.
+        Outlines API endpoints specific to the OAuth 2 framework [RFC 6749](https://tools.ietf.org/html/rfc6749)
+      required:
+        - authorizationUrl
+        - tokenUrl
+      properties:
+        serviceInfoUrl:
+          type: string
+          format: uri
+          description: |
+            If the authorization server itself implements the `service-info` endpoint, this property
+            provides the full URL to that endpoint
+          example: https://authorization-server.com/service-info
+        authorizationUrl:
+          type: string
+          format: uri
+          description: |
+            The full URL to the authorization server's **Authorization Endpoint** ([RFC 6749 3.1](https://tools.ietf.org/html/rfc6749#section-3.1)),
+            that is, the endpoint that provides an authorization grant.
+          example: https://authorization-server.com/oauth/authorize
+        tokenUrl:
+          type: string
+          format: uri
+          description: |
+            The full URL to the authorization server's **Token Endpoint** ([RFC 6749 3.2](https://tools.ietf.org/html/rfc6749#section-3.2)),
+            that is, the endpoint that provides an access token once supplied with a valid authorization grant/refresh token.
+          example: https://authorization-server.com/oauth/token
+    ScopeDefinition:
+      description: |
+        Indicates the scope(s) that must be provided to the authorization server's authorization endpoint
+        for a given set of protected resources on the resource server / web service.
+      type: object
+      required:
+        - endpoint
+        - requiredScopes
+      properties:
+        endpoint:
+          type: string
+          description: |
+            A relative URL path (relative to the web service's base URL) to which the scopes apply.
+            To access protected resources behind this path, the corresponding `requiredScopes` must
+            first be supplied to the authorization server's authorization endpoint.
+          example: /reads
+        requiredScopes:
+          type: array
+          description: |
+            A list of scopes that MUST be supplied to the authorization endpoint to retrieve a valid authorization grant.
+            The list of scopes MUST be supplied via the `scope` query string parameter as a space-delimited string.
+          items:
+            type: string
+            example: getreads


### PR DESCRIPTION
Related to #67 , this PR aims to incorporate the [GA4GH FASP API Feedback](https://docs.google.com/document/d/1eeSWZ4xAEmx0E-AmFW88NCAoWiD8KQnSH6bhSgwd4gY) into the service info spec, namely by allowing services to broadcast information about how to authorize to them (either alone or as part of a registry through service registry).

The motivation is to allow clients discovering new GA4GH services to automatically authorize to them without having pre-existing knowledge of auth server location and mechanisms.

@mbarkley provided a great [document](https://docs.google.com/document/d/13ltmbP9aZ79NKS-BnI8Il1TqBj-9M9olqag4VGr80Ow) on how this could be accomplished. The document outlines the following 3 technical recommendations:

> 1. Add the base, authorization, and token URLs of a trusted authorization server to Service Info
> 2. Add required OAuth scopes and other parameters to the Service Info with room for custom and future standard extensions
> 3. Add a client registration method (more details on this below)

The PR introduces an `authInfo` property and schema into the `Service` schema, which contains the above recommendations.

 > 1. Add the base, authorization, and token URLs of a trusted authorization server to Service Info

This is addressed by `AuthInfo`'s `authServer` property, which contains 3 Authorization Server URLs: 1 for an optional `service-info` endpoint, one for the OAuth **authorization endpoint**, and one for the OAuth **token endpoint**

> 2. Add required OAuth scopes and other parameters to the Service Info with room for custom and future standard extensions

This is partially addressed by `AuthInfo`'s `scopeDefinitions` property, which maps controlled endpoints on the GA4GH resource server to the scope(s) one would need to pass to the authorization server to gain access to them.

Currently, custom parameters are not yet addressed in this PR, though they should be.

> 3. Add a client registration method (more details on this below)

Not currently incorporated into this PR, though it should be.

@ianfore this should help in the FASP scripts making use of registry, allowing access to the DRS servers without handling tokens manually on the client machine

@mcupak 